### PR TITLE
[WIP] oneDNN Verbose Log Parsing - Integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ __Dependencies:__
 - openpyxl
 - prettytable
 
+## Usage
+``` sh
+> popcorn +[LOG] .. [-h] [-a ANALYZER] [-cat CATEGORY] [-o OUTPUT]
+          [-ot OUTPUT_TYPE] [-f, --folder] [--no-uniques]
+          [-q, --quiet] [-v, --verbose] [-dnnl] 
+```
+
+### Arguments
+  - `{-h,--help}` -- display help message and exit.
+  - `{-a,--analyzer} STRING` -- `pops` -> hotspots; `kdiff` -> kernel differences. Default is `all`.
+  - `{-o,--output} STRING` -- output file name. Default is `result`.
+  - `{-ot,--output-type} STRING` -- output type. Default is `xlsx`.
+  - `{-dnnl}` -- enable oneDNN verbose log parser mode. Default is `False`.
+  - `{--no-uniques}` -- disable grouping for similar types. Default is `False`.
+  - `{-f,--folder}` -- enable directory as input. Default is `False`.
+  - `{-v,--verbose}` -- verbose mode. Default is `False`.
+  - `{-q,--quiet}` -- Display minimal report to console. Default is `False`.
+
+
+
 ## Quick Start
 
 __Use all default settings:__

--- a/popcorn/__main__.py
+++ b/popcorn/__main__.py
@@ -107,14 +107,12 @@ def main_cli() -> str | None:
     args = parser.parse_args()
     
     reader = (OnednnTracerCsvReader()) if (args.dnnl) else (LevelZeroTracerJsonReader())
-    
     # TODO: add more input file formats? and add 'input_type' option to control manually? and autodetect?
 
     if args.folder_input:
         args.folders: list[str] = args.files
         args.files: list[str] = []
         for folder in args.folders:
-            print(folder)
             if os.path.exists(os.path.abspath(folder)):
                 supported_files: list[str] = []
                 for (dirpath, _, filenames) in os.walk(folder):

--- a/popcorn/__main__.py
+++ b/popcorn/__main__.py
@@ -13,7 +13,7 @@ import sys
 
 from popcorn.interfaces import Verbosity, Kettle, MDTables, CSVArchive
 from popcorn.reporters import report_hotspots, report_kdiff
-from popcorn.readers import LevelZeroTracerJsonReader
+from popcorn.readers import LevelZeroTracerJsonReader, OnednnTracerCsvReader
 from popcorn.structures import Case
 
 __version__ = "0.0.2"
@@ -102,7 +102,8 @@ def main_cli() -> str | None:
     args = parser.parse_args()
 
     reader = (
-        LevelZeroTracerJsonReader()
+    #LevelZeroTracerJsonReader()
+        OnednnTracerCsvReader
     )  # TODO: add more input file formats? and add 'input_type' option to control manually? and autodetect?
 
     if args.folder_input:

--- a/popcorn/__main__.py
+++ b/popcorn/__main__.py
@@ -165,6 +165,10 @@ def main_cli() -> str | None:
             "!!! - WARNING - !!!\nIf using large input files in conjunction with --no-uniques,\npopcorn may degrade in performance and even crash!"
         )
 
+    # no category specified for onednn log -> default to primitive cat
+    if args.dnnl and args.category is not "primitive":
+        args.category = "primitive"
+    
     # extract cases from json files
     cases: list[Case] = []
     for input_filename in args.files:

--- a/popcorn/__main__.py
+++ b/popcorn/__main__.py
@@ -99,12 +99,16 @@ def main_cli() -> str | None:
         version="%(prog)s {version}".format(version=__version__),
     )
 
+    parser.add_argument(
+        "-dnnl",
+        action="store_true",
+        help="parse onednn csv logs",
+    )
     args = parser.parse_args()
-
-    reader = (
-    #LevelZeroTracerJsonReader()
-        OnednnTracerCsvReader()
-    )  # TODO: add more input file formats? and add 'input_type' option to control manually? and autodetect?
+    
+    reader = (OnednnTracerCsvReader()) if (args.dnnl) else (LevelZeroTracerJsonReader())
+    
+    # TODO: add more input file formats? and add 'input_type' option to control manually? and autodetect?
 
     if args.folder_input:
         args.folders: list[str] = args.files

--- a/popcorn/__main__.py
+++ b/popcorn/__main__.py
@@ -103,13 +103,14 @@ def main_cli() -> str | None:
 
     reader = (
     #LevelZeroTracerJsonReader()
-        OnednnTracerCsvReader
+        OnednnTracerCsvReader()
     )  # TODO: add more input file formats? and add 'input_type' option to control manually? and autodetect?
 
     if args.folder_input:
         args.folders: list[str] = args.files
         args.files: list[str] = []
         for folder in args.folders:
+            print(folder)
             if os.path.exists(os.path.abspath(folder)):
                 supported_files: list[str] = []
                 for (dirpath, _, filenames) in os.walk(folder):

--- a/popcorn/analyzers.py
+++ b/popcorn/analyzers.py
@@ -1,7 +1,7 @@
 from itertools import combinations
 
 from popcorn.structures import Case
-from popcorn.events import Event, OneDnnEvent, LevelZeroEvent
+from popcorn.events import Event
 
 
 def _hs(cs: Case) -> list[Event]:

--- a/popcorn/analyzers.py
+++ b/popcorn/analyzers.py
@@ -1,6 +1,7 @@
 from itertools import combinations
 
-from popcorn.structures import Case, Event
+from popcorn.structures import Case
+from popcorn.events import Event, OneDnnEvent, LevelZeroEvent
 
 
 def _hs(cs: Case) -> list[Event]:

--- a/popcorn/dnn.py
+++ b/popcorn/dnn.py
@@ -10,41 +10,36 @@ class dnn_log:
         return
 
     def load_csv_log(self, log):
-        print("call to load_csv_log")
         self.filename = log
         self.with_timestamp = True
-        data = self.load_log_dnnl_timestamp_backend()
-        count = data['time'].count()
-        print("finished load_log_dnnl_timestamp_backend(log)")
-       
-        if count <= 1:
-            data = self.load_log_dnnl_timestamp()
-            count = data['time'].count()
-            self.with_timestamp = True
-        
-            if data['time'].count() <= 1:
-                print("ONEDNN_VERBOSE_TIMESTAMP MISSING")
-                return 0
-
-        exec_data = data[data['exec'] == 'exec']
+        data = self.load_dnnl_log()
         self.data = data
-        self.exec_data = exec_data.copy()
 
         return data
 
     def load_log_dnnl_timestamp(self):
         # dnnl_verbose,629411020589.218018,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
-        print("load_log_dnnl_timestamp")
-        print(self.filename)
         data = pd.read_csv(self.filename, names=[ 'dnnl_verbose','timestamp','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
         
         return data
 
     def load_log_dnnl_timestamp_backend(self):
-        print("oad_log_dnnl_timestamp_backend")
-        print(self.filename)
         #"onednn_verbose,operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc"
         # dnnl_verbose,629411020589.218018,primitive,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
         data = pd.read_csv(self.filename, names=[ 'dnnl_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
         
+        return data
+    
+
+    def load_dnnl_log(self):
+        import csv
+        data = []
+
+        with open(self.filename) as f:
+            for line in csv.DictReader(f, fieldnames=('onednn_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy')):
+                if(line['timestamp'] in ['info', 'graph', 'primitive']):
+                    continue
+                else:
+                    data.append(line)
+                    print(line)
         return data

--- a/popcorn/dnn.py
+++ b/popcorn/dnn.py
@@ -1,6 +1,3 @@
-import pandas as pd
-
-
 class dnn_log:
     def __init_(self):
         self.filename = ''
@@ -17,18 +14,6 @@ class dnn_log:
 
         return data
 
-    def load_log_dnnl_timestamp(self):
-        # dnnl_verbose,629411020589.218018,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
-        data = pd.read_csv(self.filename, names=[ 'dnnl_verbose','timestamp','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
-        
-        return data
-
-    def load_log_dnnl_timestamp_backend(self):
-        #"onednn_verbose,operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc"
-        # dnnl_verbose,629411020589.218018,primitive,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
-        data = pd.read_csv(self.filename, names=[ 'dnnl_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
-        
-        return data
     
 
     def load_dnnl_log(self):

--- a/popcorn/dnn.py
+++ b/popcorn/dnn.py
@@ -10,13 +10,15 @@ class dnn_log:
         return
 
     def load_csv_log(self, log):
+        print("call to load_csv_log")
         self.filename = log
         self.with_timestamp = True
-        data = self.load_log_dnnl_timestamp_backend(log)
+        data = self.load_log_dnnl_timestamp_backend()
         count = data['time'].count()
+        print("finished load_log_dnnl_timestamp_backend(log)")
        
         if count <= 1:
-            data = self.load_log_dnnl_timestamp(log)
+            data = self.load_log_dnnl_timestamp()
             count = data['time'].count()
             self.with_timestamp = True
         
@@ -30,14 +32,19 @@ class dnn_log:
 
         return data
 
-    def load_log_dnnl_timestamp(self, log):
+    def load_log_dnnl_timestamp(self):
         # dnnl_verbose,629411020589.218018,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
-        data = pd.read_csv(log, names=[ 'dnnl_verbose','timestamp','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
+        print("load_log_dnnl_timestamp")
+        print(self.filename)
+        data = pd.read_csv(self.filename, names=[ 'dnnl_verbose','timestamp','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
         
         return data
 
-    def load_log_dnnl_timestamp_backend(self, log):
+    def load_log_dnnl_timestamp_backend(self):
+        print("oad_log_dnnl_timestamp_backend")
+        print(self.filename)
+        #"onednn_verbose,operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc"
         # dnnl_verbose,629411020589.218018,primitive,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
-        data = pd.read_csv(log, names=[ 'dnnl_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
+        data = pd.read_csv(self.filename, names=[ 'dnnl_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
         
         return data

--- a/popcorn/dnn.py
+++ b/popcorn/dnn.py
@@ -36,7 +36,7 @@ class dnn_log:
         data = []
 
         with open(self.filename) as f:
-            for line in csv.DictReader(f, fieldnames=('onednn_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy')):
+            for line in csv.DictReader(f, fieldnames=('onednn_verbose','timestamp','backend','exec','arch','type', 'kernel', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy')):
                 if(line['timestamp'] in ['info', 'graph', 'primitive']):
                     continue
                 else:

--- a/popcorn/dnn.py
+++ b/popcorn/dnn.py
@@ -14,7 +14,6 @@ class dnn_log:
 
         return data
 
-    
 
     def load_dnnl_log(self):
         import csv
@@ -23,6 +22,7 @@ class dnn_log:
         with open(self.filename) as f:
             for line in csv.DictReader(f, fieldnames=('onednn_verbose','timestamp','backend','exec','arch','type', 'kernel', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy')):
                 if(line['timestamp'] in ['info', 'graph', 'primitive']):
+                    # break if it is a info line, not needed
                     continue
                 else:
                     data.append(line)

--- a/popcorn/dnn.py
+++ b/popcorn/dnn.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+
+class dnn_log:
+    def __init_(self):
+        self.filename = ''
+        self.data = None
+        self.exec_data = None
+        self.with_timestamp = True
+        return
+
+    def load_csv_log(self, log):
+        self.filename = log
+        self.with_timestamp = True
+        data = self.load_log_dnnl_timestamp_backend(log)
+        count = data['time'].count()
+       
+        if count <= 1:
+            data = self.load_log_dnnl_timestamp(log)
+            count = data['time'].count()
+            self.with_timestamp = True
+        
+            if data['time'].count() <= 1:
+                print("ONEDNN_VERBOSE_TIMESTAMP MISSING")
+                return 0
+
+        exec_data = data[data['exec'] == 'exec']
+        self.data = data
+        self.exec_data = exec_data.copy()
+
+        return data
+
+    def load_log_dnnl_timestamp(self, log):
+        # dnnl_verbose,629411020589.218018,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
+        data = pd.read_csv(log, names=[ 'dnnl_verbose','timestamp','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
+        
+        return data
+
+    def load_log_dnnl_timestamp_backend(self, log):
+        # dnnl_verbose,629411020589.218018,primitive,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
+        data = pd.read_csv(log, names=[ 'dnnl_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
+        
+        return data

--- a/popcorn/dnn.py
+++ b/popcorn/dnn.py
@@ -26,5 +26,4 @@ class dnn_log:
                     continue
                 else:
                     data.append(line)
-                    print(line)
         return data

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -67,12 +67,7 @@ class OneDnnEvent(Event):
 
     def row(self) -> list[str]:
         return [
-            self.ph,
-            str(self.tid),
-            str(self.pid),
             self.dname,
-            self.cat,
-            str(self.ts),
             str(self.dur),
             str(self.kernel),
             str(self.shape),
@@ -83,7 +78,6 @@ class OneDnnEvent(Event):
     def diff_row(self) -> list[str]:
         return [
             self.dname,
-            self.cat,
             str(self.kernel),
             str(self.shape),
             str(self.ncalls),
@@ -92,10 +86,10 @@ class OneDnnEvent(Event):
     
         
     def header(self) -> list[str]:
-        return (["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "ncalls", "args"])
+        return (["name", "dur", "kernel", "shape", "ncalls", "args"])
     
     def diff_header(self) -> list[str]:
-        return (["name", "cat", "kernel", "shape", "ncalls", "args"])
+        return (["name", "kernel", "shape", "ncalls", "args"])
 
 
 class LevelZeroEvent(Event):

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -28,7 +28,7 @@ class Event(ABC):
             str(self.dur),]
             
     @abstractmethod
-    def header(self) -> list[str]: #TODO: fix this
+    def header(self) -> list[str]: 
         pass
       
 
@@ -40,6 +40,7 @@ class OneDnnEvent(Event):
         tid=-1,
         pid=-1,
         name="N/A",
+        dname="N/A",
         cat="N/A",
         kernel="N/A",
         shape="N/A",
@@ -49,6 +50,7 @@ class OneDnnEvent(Event):
         args=[],
     ):
         Event.__init__(self, name, cat, ts, dur) 
+        self.dname = dname
         self.ph = ph
         self.tid = tid
         self.pid = pid
@@ -68,7 +70,7 @@ class OneDnnEvent(Event):
             self.ph,
             str(self.tid),
             str(self.pid),
-            self.name,
+            self.dname,
             self.cat,
             str(self.ts),
             str(self.dur),
@@ -79,7 +81,7 @@ class OneDnnEvent(Event):
         ]
         
     def header(self) -> list[str]:
-        return (["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape","ncalls", "args"])
+        return (["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "ncalls", "args"])
 
 
 class LevelZeroEvent(Event):

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -79,9 +79,23 @@ class OneDnnEvent(Event):
             str(self.ncalls),
             self.args,
         ]
+    
+    def diff_row(self) -> list[str]:
+        return [
+            self.dname,
+            self.cat,
+            str(self.kernel),
+            str(self.shape),
+            str(self.ncalls),
+            self.args,
+        ]
+    
         
     def header(self) -> list[str]:
         return (["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "ncalls", "args"])
+    
+    def diff_header(self) -> list[str]:
+        return (["name", "cat", "kernel", "shape", "ncalls", "args"])
 
 
 class LevelZeroEvent(Event):
@@ -122,6 +136,20 @@ class LevelZeroEvent(Event):
             str(self.dur),
             str(self.args_id),
         ]
+    
+    def diff_row(self) -> list[str]:
+        return [
+            self.ph,
+            str(self.tid),
+            str(self.pid),
+            self.name,
+            self.cat,
+            str(self.id),
+            str(self.args_id),
+        ]
         
     def header(self) -> list[str]:
         return (["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"])
+    
+    def diff_header(self) -> list[str]:
+        return (["ph", "tid", "pid", "name", "cat", "id", "args_id"])

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -16,7 +16,7 @@ class Event(ABC):
 
 
     def __eq__(self, other):
-        if isinstance(other, BaseEvent):
+        if isinstance(other, Event):
             return self.name == other.name
         return False
 
@@ -28,8 +28,8 @@ class Event(ABC):
             str(self.dur),]
             
     @abstractmethod
-    def header() -> list[str]:
-        raise NotImplementedError("Error header")
+    def header() -> list[str]: #TODO: fix this
+        return [ "name", "cat", "dur"]
       
 
 
@@ -75,7 +75,6 @@ class OneDnnEvent(Event):
             str(self.kernel),
         ]
     
-    @staticmethod
     def header() -> list[str]:
         return ["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "args"]
 
@@ -118,6 +117,5 @@ class LevelZeroEvent(Event):
             str(self.args_id),
         ]
     
-    @staticmethod
     def header() -> list[str]:
         return ["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"]

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -41,6 +41,7 @@ class OneDnnEvent(Event):
         pid=-1,
         name="N/A",
         dname="N/A",
+        arch = "N/A",
         cat="N/A",
         kernel="N/A",
         shape="N/A",
@@ -51,6 +52,7 @@ class OneDnnEvent(Event):
     ):
         Event.__init__(self, name, cat, ts, dur) 
         self.dname = dname
+        self.arch = arch
         self.ph = ph
         self.tid = tid
         self.pid = pid
@@ -70,6 +72,7 @@ class OneDnnEvent(Event):
             self.dname,
             str(self.dur),
             str(self.kernel),
+            str(self.arch),
             str(self.shape),
             str(self.ncalls),
             self.args,
@@ -79,6 +82,7 @@ class OneDnnEvent(Event):
         return [
             self.dname,
             str(self.kernel),
+            str(self.arch),
             str(self.shape),
             str(self.ncalls),
             self.args,
@@ -86,10 +90,10 @@ class OneDnnEvent(Event):
     
         
     def header(self) -> list[str]:
-        return (["name", "dur(ms)", "kernel", "shape", "ncalls", "args"])
+        return (["name", "dur(ms)", "kernel", "arch", "shape", "ncalls", "args"])
     
     def diff_header(self) -> list[str]:
-        return (["diff(ms)", "name", "kernel", "shape", "ncalls", "args"])
+        return (["diff(ms)", "name", "kernel", "arch", "shape", "ncalls", "args"])
 
 
 class LevelZeroEvent(Event):

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -27,9 +27,9 @@ class Event(ABC):
             str(self.ts),
             str(self.dur),]
             
-    @abstractmethod
+    @staticmethod
     def header() -> list[str]: #TODO: fix this
-        return [ "name", "cat", "dur"]
+        return [ "name", "cat","ts", "dur"]
       
 
 
@@ -74,8 +74,9 @@ class OneDnnEvent(Event):
             str(self.shape),
             str(self.kernel),
         ]
-    
-    def header() -> list[str]:
+        
+    @staticmethod
+    def header(self) -> list[str]:
         return ["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "args"]
 
 class LevelZeroEvent(Event):
@@ -116,6 +117,7 @@ class LevelZeroEvent(Event):
             str(self.dur),
             str(self.args_id),
         ]
-    
-    def header() -> list[str]:
+        
+    @staticmethod
+    def header(self) -> list[str]:
         return ["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"]

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -1,0 +1,123 @@
+from abc import ABC, abstractmethod
+
+class Event(ABC):
+    def __init__(
+        self,
+        name="N/A",
+        cat="N/A",
+        ts=0,
+        dur=0,
+    ):
+
+        self.name = name
+        self.cat = cat
+        self.ts = ts
+        self.dur = dur
+
+
+    def __eq__(self, other):
+        if isinstance(other, BaseEvent):
+            return self.name == other.name
+        return False
+
+    def row(self) -> list[str]:
+        return [
+            self.name,
+            self.cat,
+            str(self.ts),
+            str(self.dur),]
+            
+    @abstractmethod
+    def header() -> list[str]:
+        raise NotImplementedError("Error header")
+      
+
+
+class OneDnnEvent(Event):
+    def __init__(
+        self,
+        ph="",
+        tid=-1,
+        pid=-1,
+        name="N/A",
+        cat="N/A",
+        kernel="N/A",
+        shape="N/A",
+        ts=0,
+        dur=0,
+        args=[],
+    ):
+        Event.__init__(self, name, cat, ts, dur) 
+        self.ph = ph
+        self.tid = tid
+        self.pid = pid
+        self.args = args
+        self.shape = shape
+        self.kernel = kernel
+
+
+    def __eq__(self, other):
+        if isinstance(other, OneDnnEvent):
+            return self.name == other.name
+        return False
+
+    def row(self) -> list[str]:
+        return [
+            self.ph,
+            str(self.tid),
+            str(self.pid),
+            self.name,
+            self.cat,
+            str(self.ts),
+            str(self.dur),
+            self.args,
+            str(self.shape),
+            str(self.kernel),
+        ]
+    
+    @staticmethod
+    def header() -> list[str]:
+        return ["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "args"]
+
+class LevelZeroEvent(Event):
+    def __init__(
+        self,
+        ph="",
+        tid=-1,
+        pid=-1,
+        name="N/A",
+        cat="N/A",
+        ts=0,
+        id=-1,
+        dur=0,
+        args_id=-1,
+    ):
+        Event.__init__(self, name, cat, ts, dur) 
+        self.ph = ph
+        self.tid = tid
+        self.pid = pid
+        self.cat = cat
+        self.id = id
+        self.args_id = args_id
+
+    def __eq__(self, other):
+        if isinstance(other, LevelZeroEvent):
+            return self.name == other.name
+        return False
+
+    def row(self) -> list[str]:
+        return [
+            self.ph,
+            str(self.tid),
+            str(self.pid),
+            self.name,
+            self.cat,
+            str(self.ts),
+            str(self.id),
+            str(self.dur),
+            str(self.args_id),
+        ]
+    
+    @staticmethod
+    def header() -> list[str]:
+        return ["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"]

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -27,9 +27,9 @@ class Event(ABC):
             str(self.ts),
             str(self.dur),]
             
-    @staticmethod
-    def header() -> list[str]: #TODO: fix this
-        return [ "name", "cat","ts", "dur"]
+    @abstractmethod
+    def header(self) -> list[str]: #TODO: fix this
+        pass
       
 
 
@@ -51,9 +51,9 @@ class OneDnnEvent(Event):
         self.ph = ph
         self.tid = tid
         self.pid = pid
-        self.args = args
-        self.shape = shape
         self.kernel = kernel
+        self.shape = shape
+        self.args = args
 
 
     def __eq__(self, other):
@@ -70,14 +70,14 @@ class OneDnnEvent(Event):
             self.cat,
             str(self.ts),
             str(self.dur),
-            self.args,
-            str(self.shape),
             str(self.kernel),
+            str(self.shape),
+            self.args,
         ]
         
-    @staticmethod
     def header(self) -> list[str]:
-        return ["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "args"]
+        return (["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "args"])
+
 
 class LevelZeroEvent(Event):
     def __init__(
@@ -118,6 +118,5 @@ class LevelZeroEvent(Event):
             str(self.args_id),
         ]
         
-    @staticmethod
     def header(self) -> list[str]:
-        return ["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"]
+        return (["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"])

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -6,7 +6,7 @@ class Event(ABC):
         name="N/A",
         cat="N/A",
         ts=0,
-        dur=0,
+        dur=0.0,
     ):
 
         self.name = name
@@ -44,7 +44,8 @@ class OneDnnEvent(Event):
         kernel="N/A",
         shape="N/A",
         ts=0,
-        dur=0,
+        dur=0.0,
+        ncalls=0,
         args=[],
     ):
         Event.__init__(self, name, cat, ts, dur) 
@@ -53,6 +54,7 @@ class OneDnnEvent(Event):
         self.pid = pid
         self.kernel = kernel
         self.shape = shape
+        self.ncalls = ncalls
         self.args = args
 
 
@@ -72,11 +74,12 @@ class OneDnnEvent(Event):
             str(self.dur),
             str(self.kernel),
             str(self.shape),
+            str(self.ncalls),
             self.args,
         ]
         
     def header(self) -> list[str]:
-        return (["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape", "args"])
+        return (["ph", "tid", "pid", "name", "cat", "ts", "dur", "kernel", "shape","ncalls", "args"])
 
 
 class LevelZeroEvent(Event):

--- a/popcorn/events.py
+++ b/popcorn/events.py
@@ -86,10 +86,10 @@ class OneDnnEvent(Event):
     
         
     def header(self) -> list[str]:
-        return (["name", "dur", "kernel", "shape", "ncalls", "args"])
+        return (["name", "dur(ms)", "kernel", "shape", "ncalls", "args"])
     
     def diff_header(self) -> list[str]:
-        return (["name", "kernel", "shape", "ncalls", "args"])
+        return (["diff(ms)", "name", "kernel", "shape", "ncalls", "args"])
 
 
 class LevelZeroEvent(Event):
@@ -146,4 +146,4 @@ class LevelZeroEvent(Event):
         return (["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"])
     
     def diff_header(self) -> list[str]:
-        return (["ph", "tid", "pid", "name", "cat", "id", "args_id"])
+        return (["diff", "ph", "tid", "pid", "name", "cat", "id", "args_id"])

--- a/popcorn/interfaces.py
+++ b/popcorn/interfaces.py
@@ -28,7 +28,6 @@ class Kettle:
 
     def print_table(self, title: str, fields: list[str], data: list[list[str]]):
         table = PrettyTable(title=title, field_names=fields)
-
         limit = self.verbosity.limit
         if (limit > 0) and (len(data) > (2 * limit)):
             table.add_rows(data[:limit] + data[-limit:])

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -77,13 +77,13 @@ class OnednnTracerCsvReader(Reader):
     def create_event_from_trace_item(self, item) -> Event:
         event = Event()
         event.ph = _getv(item, "ph", default="N/A")
-        event.tid = _getv(item, "tid")
-        event.pid = _getv(item, "pid")
-        event.name = _getv(item, "name", default="N/A")
-        event.cat = _getv(item, "cat", default="N/A")
-        event.ts = _getv(item, "ts")
-        event.id = _getv(item, "id")
-        event.dur = _getv(item, "dur", default=0)
+        event.tid = _getv(item, "tid", default="N/A")
+        event.pid = _getv(item, "pid", default="N/A")
+        event.name = _getv(item, "type", default="N/A")
+        event.cat = _getv(item, "backend", default="N/A")
+        event.ts = _getv(item, "timestamp")
+        event.id = _getv(item, "id", default="N/A")
+        event.dur = _getv(item, "time", default=0)
         event.args_id = (
             item["args"]["id"]
             if (("args" in item.keys()) and ("id" in item["args"].keys()))
@@ -96,28 +96,26 @@ class OnednnTracerCsvReader(Reader):
             unique_events: dict[str, Event] = {}
 
             new_log = dnn_log()
-            #print("Filename 1:  ->  " + filename)
             data = new_log.load_csv_log(filename)
             
             for item in data:
                 item_name = _getv(item, "name", default="N/A")
-                item_category = _getv(item, "cat", default=False)
+                item_category = _getv(item, "backend", default=False)
                 same_category = item_category and (item_category == cat)
                 if (not cat) or same_category:  # no filter applied or category matches
-                    if item_name in unique_events:  # collapse uniques duration
-                        unique_events[item_name].dur += _getv(item, "dur", default=0)
-                    else:
-                        unique_events[item_name] = self.create_event_from_trace_item(item)
+                    #if item_name in unique_events:  # collapse uniques duration
+                       # unique_events[item_name].dur += _getv(item, "dur", default=0)
+                    #else:
+                    unique_events[item_name] = self.create_event_from_trace_item(item)
 
-                    return list(unique_events.values())
+            return list(unique_events.values())
 
         else:
             trace_events: list[Event] = []
-            #print("Filename 2:  ->  " + filename)
             new_log = dnn_log()
             data = new_log.load_csv_log(filename)
             for item in data:
-                item_category = _getv(item, "cat", default=False)
+                item_category = _getv(item, "backend", default=False)
                 same_category = item_category and (item_category == cat)
                 if (not cat) or same_category:  # no filter applied or category matches
                     trace_events.append(self.create_event_from_trace_item(item))

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -1,4 +1,5 @@
 from json import load as load_json
+from popcorn.dnn import dnn_log
 
 from popcorn.structures import Event, Reader
 
@@ -65,3 +66,73 @@ class LevelZeroTracerJsonReader(Reader):
                         trace_events.append(self.create_event_from_trace_item(item))
 
             return trace_events
+
+
+
+
+class OnednnTracerCsvReader(Reader):
+    def __init__(self):
+        super().__init__(format="csv")
+
+    def create_event_from_trace_item(self, item) -> Event:
+        event = Event()
+        event.ph = _getv(item, "ph", default="N/A")
+        event.tid = _getv(item, "tid")
+        event.pid = _getv(item, "pid")
+        event.name = _getv(item, "name", default="N/A")
+        event.cat = _getv(item, "cat", default="N/A")
+        event.ts = _getv(item, "ts")
+        event.id = _getv(item, "id")
+        event.dur = _getv(item, "dur", default=0)
+        event.args_id = (
+            item["args"]["id"]
+            if (("args" in item.keys()) and ("id" in item["args"].keys()))
+            else -1
+        )
+        return event
+
+    def read(self, filename: str, uniques: bool = True, cat: str | None = None) -> list[Event]:
+        print("reading")
+        if uniques:
+            unique_events: dict[str, Event] = {}
+
+            with open(filename, "r") as f:
+                new_log = dnn_log()
+                data = new_log.load_csv_log(f)
+                print(data)
+                for item in data:
+                    item_name = _getv(item, "name", default="N/A")
+                    item_category = _getv(item, "cat", default=False)
+                    same_category = item_category and (item_category == cat)
+                    if (
+                        not cat
+                    ) or same_category:  # no filter applied or category matches
+                        if item_name in unique_events:  # collapse uniques duration
+                            unique_events[item_name].dur += _getv(
+                                item, "dur", default=0
+                            )
+                        else:
+                            unique_events[
+                                item_name
+                            ] = self.create_event_from_trace_item(item)
+
+            return list(unique_events.values())
+        else:
+            trace_events: list[Event] = []
+
+            with open(filename, "r") as f:
+                new_log = dnn_log()
+                data = new_log.load_csv_log(f)
+                print(data)
+                for item in data:
+                    item_category = _getv(item, "cat", default=False)
+                    same_category = item_category and (item_category == cat)
+                    if (
+                        not cat
+                    ) or same_category:  # no filter applied or category matches
+                        trace_events.append(self.create_event_from_trace_item(item))
+
+            return trace_events
+        
+
+

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -1,7 +1,11 @@
-from json import load as load_json
-from popcorn.dnn import dnn_log
 
-from popcorn.structures import Event, Reader
+from popcorn.dnn import dnn_log
+from popcorn.structures import Reader
+from popcorn.structures import Event, OneDnnEvent, LevelZeroEvent
+from json import load as load_json
+import os
+import threading
+
 
 
 def _getv(item: dict, prop: str, default: str | int | bool = -1) -> str | int | bool:
@@ -71,54 +75,41 @@ class LevelZeroTracerJsonReader(Reader):
 
 
 class OnednnTracerCsvReader(Reader):
+
+    TYPES = {'call': 'B', 'return': 'E', 'exec': 'X'}
+
     def __init__(self):
         super().__init__(format="csv")
+        self.pid = os.getpid()
 
-    def create_event_from_trace_item(self, item) -> Event:
-        event = Event()
-        event.ph = _getv(item, "ph", default="N/A")
-        event.tid = _getv(item, "tid", default="N/A")
-        event.pid = _getv(item, "pid", default="N/A")
+    @property
+    def thread_id(self):
+        return threading.current_thread().name
+
+    def create_event_from_trace_item(self, item) -> OneDnnEvent:
+        event = OneDnnEvent()
+        event.ph = self.TYPES[_getv(item, "exec", default="N/A")]
+        event.tid = self.thread_id
+        event.pid = self.pid
         event.name = _getv(item, "type", default="N/A")
         event.cat = _getv(item, "backend", default="N/A")
         event.ts = _getv(item, "timestamp")
         event.id = _getv(item, "id", default="N/A")
         event.dur = _getv(item, "time", default=0)
-        event.args_id = (
-            item["args"]["id"]
-            if (("args" in item.keys()) and ("id" in item["args"].keys()))
-            else -1
-        )
+        event.args = []
+        event.kernel = _getv(item, "kernel", default="N/A")
+        event.shape = _getv(item, "shape", default="N/A")
         return event
 
-    def read(self, filename: str, uniques: bool = True, cat: str | None = None) -> list[Event]:
-        if uniques:
-            unique_events: dict[str, Event] = {}
-
-            new_log = dnn_log()
-            data = new_log.load_csv_log(filename)
-            
-            for item in data:
-                item_name = _getv(item, "name", default="N/A")
-                item_category = _getv(item, "backend", default=False)
-                same_category = item_category and (item_category == cat)
-                if (not cat) or same_category:  # no filter applied or category matches
-                    #if item_name in unique_events:  # collapse uniques duration
-                       # unique_events[item_name].dur += _getv(item, "dur", default=0)
-                    #else:
-                    unique_events[item_name] = self.create_event_from_trace_item(item)
-
-            return list(unique_events.values())
-
-        else:
-            trace_events: list[Event] = []
-            new_log = dnn_log()
-            data = new_log.load_csv_log(filename)
-            for item in data:
-                item_category = _getv(item, "backend", default=False)
-                same_category = item_category and (item_category == cat)
-                if (not cat) or same_category:  # no filter applied or category matches
-                    trace_events.append(self.create_event_from_trace_item(item))
+    def read(self, filename: str, uniques: bool = True, cat: str | None = None) -> list[OneDnnEvent]:
+        trace_events: list[OneDnnEvent] = []
+        new_log = dnn_log()
+        data = new_log.load_csv_log(filename)
+        for item in data:
+            item_category = _getv(item, "backend", default=False)
+            same_category = item_category and (item_category == cat)
+            if (not cat) or same_category:  # no filter applied or category matches
+                trace_events.append(self.create_event_from_trace_item(item))
 
         return trace_events
         

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -1,4 +1,3 @@
-
 from popcorn.dnn import dnn_log
 from popcorn.structures import Reader
 from popcorn.events import Event, OneDnnEvent, LevelZeroEvent
@@ -17,7 +16,7 @@ class LevelZeroTracerJsonReader(Reader):
         super().__init__(format="json")
 
     def create_event_from_trace_item(self, item) -> Event:
-        event = Event()
+        event = LevelZeroEvent()
         event.ph = _getv(item, "ph", default="N/A")
         event.tid = _getv(item, "tid")
         event.pid = _getv(item, "pid")

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -71,8 +71,6 @@ class LevelZeroTracerJsonReader(Reader):
             return trace_events
 
 
-
-
 class OnednnTracerCsvReader(Reader):
     TYPES = {'call': 'B', 'return': 'E', 'exec': 'X'}
 

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -88,6 +88,7 @@ class OnednnTracerCsvReader(Reader):
         event.tid = self.thread_id
         event.pid = self.pid
         event.name = _getv(item, "type", default="N/A")
+        event.arch = _getv(item, "arch", default="N/A")
         event.dname = _getv(item, "type", default="N/A")
         event.name += _getv(item, "shape", default="N/A")
         event.cat = _getv(item, "backend", default="N/A")

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -90,6 +90,8 @@ class OnednnTracerCsvReader(Reader):
         event.tid = self.thread_id
         event.pid = self.pid
         event.name = _getv(item, "type", default="N/A")
+        event.dname = _getv(item, "type", default="N/A")
+        event.name += _getv(item, "shape", default="N/A")
         event.cat = _getv(item, "backend", default="N/A")
         event.ts = _getv(item, "timestamp")
         event.id = _getv(item, "id", default="N/A")
@@ -122,7 +124,7 @@ class OnednnTracerCsvReader(Reader):
                             ] = self.create_event_from_trace_item(item)
 
             return list(unique_events.values())
-
+        
         else:    
             trace_events: list[OneDnnEvent] = []
             new_log = dnn_log()

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -97,6 +97,7 @@ class OnednnTracerCsvReader(Reader):
         event.args = []
         event.kernel = _getv(item, "kernel", default="N/A")
         event.shape = _getv(item, "shape", default="N/A")
+        event.ncalls = 1
         return event
 
     def read(self, filename: str, uniques: bool = True, cat: str | None = None) -> list[OneDnnEvent]:
@@ -114,6 +115,7 @@ class OnednnTracerCsvReader(Reader):
                     ) or same_category:  # no filter applied or category matches
                         if item_name in unique_events:  # collapse uniques duration
                             unique_events[item_name].dur += float(_getv(item, "time", default=0))
+                            unique_events[item_name].ncalls += 1
                         else:
                             unique_events[
                                 item_name

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -92,47 +92,37 @@ class OnednnTracerCsvReader(Reader):
         return event
 
     def read(self, filename: str, uniques: bool = True, cat: str | None = None) -> list[Event]:
-        print("reading")
         if uniques:
             unique_events: dict[str, Event] = {}
 
-            with open(filename, "r") as f:
-                new_log = dnn_log()
-                data = new_log.load_csv_log(f)
-                print(data)
-                for item in data:
-                    item_name = _getv(item, "name", default="N/A")
-                    item_category = _getv(item, "cat", default=False)
-                    same_category = item_category and (item_category == cat)
-                    if (
-                        not cat
-                    ) or same_category:  # no filter applied or category matches
-                        if item_name in unique_events:  # collapse uniques duration
-                            unique_events[item_name].dur += _getv(
-                                item, "dur", default=0
-                            )
-                        else:
-                            unique_events[
-                                item_name
-                            ] = self.create_event_from_trace_item(item)
+            new_log = dnn_log()
+            #print("Filename 1:  ->  " + filename)
+            data = new_log.load_csv_log(filename)
+            
+            for item in data:
+                item_name = _getv(item, "name", default="N/A")
+                item_category = _getv(item, "cat", default=False)
+                same_category = item_category and (item_category == cat)
+                if (not cat) or same_category:  # no filter applied or category matches
+                    if item_name in unique_events:  # collapse uniques duration
+                        unique_events[item_name].dur += _getv(item, "dur", default=0)
+                    else:
+                        unique_events[item_name] = self.create_event_from_trace_item(item)
 
-            return list(unique_events.values())
+                    return list(unique_events.values())
+
         else:
             trace_events: list[Event] = []
+            #print("Filename 2:  ->  " + filename)
+            new_log = dnn_log()
+            data = new_log.load_csv_log(filename)
+            for item in data:
+                item_category = _getv(item, "cat", default=False)
+                same_category = item_category and (item_category == cat)
+                if (not cat) or same_category:  # no filter applied or category matches
+                    trace_events.append(self.create_event_from_trace_item(item))
 
-            with open(filename, "r") as f:
-                new_log = dnn_log()
-                data = new_log.load_csv_log(f)
-                print(data)
-                for item in data:
-                    item_category = _getv(item, "cat", default=False)
-                    same_category = item_category and (item_category == cat)
-                    if (
-                        not cat
-                    ) or same_category:  # no filter applied or category matches
-                        trace_events.append(self.create_event_from_trace_item(item))
-
-            return trace_events
+        return trace_events
         
 
 

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -1,7 +1,7 @@
 
 from popcorn.dnn import dnn_log
 from popcorn.structures import Reader
-from popcorn.structures import Event, OneDnnEvent, LevelZeroEvent
+from popcorn.events import Event, OneDnnEvent, LevelZeroEvent
 from json import load as load_json
 import os
 import threading

--- a/popcorn/readers.py
+++ b/popcorn/readers.py
@@ -74,7 +74,6 @@ class LevelZeroTracerJsonReader(Reader):
 
 
 class OnednnTracerCsvReader(Reader):
-
     TYPES = {'call': 'B', 'return': 'E', 'exec': 'X'}
 
     def __init__(self):

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -97,11 +97,10 @@ def report_kdiff(
     if(hotspot_first_event is None):
         print("Warning: Hotspots empty, no events found")
         return
-    kdiff_header = hotspot_first_event.diff_header()
 
     _report(
         result,
-        kdiff_header,
+        hotspot_first_event.diff_header(),
         lambda eventdiff: ([str(eventdiff[1])] + eventdiff[0].diff_row()),
         _kernel_differences_sheet_name,
         wb,

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -63,11 +63,17 @@ def _hotspots_sheet_name(item_name: str) -> str:
 
 
 def report_hotspots(
-    cases: list[Case], wb: Kettle | MDTables | Workbook | CSVArchive
+    cases: list[Case],  wb: Kettle | MDTables | Workbook | CSVArchive
 ):
     result = hotspots(cases)
-    hotspot_header = Event.header()
-    _report(result, hotspot_header, lambda e: e.row(), _hotspots_sheet_name, wb, [len(case.events) for case in cases])
+    hotspot_header = cases[0].getfirstitem()
+
+    if(hotspot_header is None):
+        print("Warning: Hotspots empty, no events found")
+        return
+    event_hotspot_header = hotspot_header.header()
+
+    _report(result, event_hotspot_header, lambda e: e.row(), _hotspots_sheet_name, wb, [len(case.events) for case in cases])
 
 
 def _kernel_differences_sheet_name(item_name: str) -> str:

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -30,6 +30,7 @@ def _report(
                 print(f"Displaying all {case_count[i]} items:")
             else:
                 print(f"Displaying the most interesting {2 * wb.verbosity.limit} items out of {case_count[i]}:")
+
             wb.print_table(
                 title=sheetnamefn(items[i][0]),
                 fields=header,

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -7,8 +7,8 @@ from popcorn.structures import Case
 
 
 
-def _ensure_console_text_fits(row: list[str]) -> list[str]:
-    trunc_limit = 25
+def _ensure_console_text_fits(header: list[str], row: list[str]) -> list[str]:
+    trunc_limit = 25 if ('shape' not in header) else 35   # oneDNN primitive shape requires higher limit
     for i in range(len(row)):
         if (not str(row[i]).isdigit()) and (len(str(row[i])) > trunc_limit):
             row[i] = row[i][:trunc_limit]
@@ -35,7 +35,7 @@ def _report(
                 title=sheetnamefn(items[i][0]),
                 fields=header,
                 data=[
-                    _ensure_console_text_fits(keyrowfn(event_row))
+                    _ensure_console_text_fits(header, keyrowfn(event_row))
                     for event_row in items[i][1]
                 ],
             )

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -66,14 +66,14 @@ def report_hotspots(
     cases: list[Case],  wb: Kettle | MDTables | Workbook | CSVArchive
 ):
     result = hotspots(cases)
-    hotspot_header = cases[0].getfirstitem()
+    hotspot_first_event = cases[0].getfirstitem()
 
-    if(hotspot_header is None):
+    if(hotspot_first_event is None):
         print("Warning: Hotspots empty, no events found")
         return
-    event_hotspot_header = hotspot_header.header()
+    hotspot_header = hotspot_first_event.header()
 
-    _report(result, event_hotspot_header, lambda e: e.row(), _hotspots_sheet_name, wb, [len(case.events) for case in cases])
+    _report(result, hotspot_header, lambda e: e.row(), _hotspots_sheet_name, wb, [len(case.events) for case in cases])
 
 
 def _kernel_differences_sheet_name(item_name: str) -> str:
@@ -85,7 +85,14 @@ def report_kdiff(
     wb: Kettle | MDTables | Workbook | CSVArchive,
 ):
     result = kernel_differences(cases)
-    kdiff_header = ["diff"] + Event.header()
+
+    hotspot_first_event = cases[0].getfirstitem()
+
+    if(hotspot_first_event is None):
+        print("Warning: Hotspots empty, no events found")
+        return
+    kdiff_header = ["diff"] + hotspot_first_event.header()
+
     _report(
         result,
         kdiff_header,

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -3,7 +3,9 @@ from openpyxl import Workbook
 from popcorn.analyzers import hotspots, kernel_differences
 
 from popcorn.interfaces import Kettle, MDTables, CSVArchive, Verbosity
-from popcorn.structures import Case, Event
+from popcorn.structures import Case
+from popcorn.events import Event
+
 
 
 def _ensure_console_text_fits(row: list[str]) -> list[str]:

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -1,10 +1,9 @@
 from typing import Callable
 from openpyxl import Workbook
-from popcorn.analyzers import hotspots, kernel_differences
 
+from popcorn.analyzers import hotspots, kernel_differences
 from popcorn.interfaces import Kettle, MDTables, CSVArchive, Verbosity
 from popcorn.structures import Case
-from popcorn.events import Event
 
 
 
@@ -63,7 +62,7 @@ def _hotspots_sheet_name(item_name: str) -> str:
 
 
 def report_hotspots(
-    cases: list[Case],  wb: Kettle | MDTables | Workbook | CSVArchive
+    cases: list[Case], wb: Kettle | MDTables | Workbook | CSVArchive
 ):
     result = hotspots(cases)
     hotspot_first_event = cases[0].getfirstitem()

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -91,12 +91,12 @@ def report_kdiff(
     if(hotspot_first_event is None):
         print("Warning: Hotspots empty, no events found")
         return
-    kdiff_header = ["diff"] + hotspot_first_event.header()
+    kdiff_header = ["diff"] + hotspot_first_event.diff_header()
 
     _report(
         result,
         kdiff_header,
-        lambda eventdiff: ([str(eventdiff[1])] + eventdiff[0].row()),
+        lambda eventdiff: ([str(eventdiff[1])] + eventdiff[0].diff_row()),
         _kernel_differences_sheet_name,
         wb,
         [len(case.events) for case in cases]

--- a/popcorn/structures.py
+++ b/popcorn/structures.py
@@ -1,6 +1,7 @@
-from popcorn.events import Event
 from abc import ABC, abstractmethod
 import os
+
+from popcorn.events import Event
 
 
 

--- a/popcorn/structures.py
+++ b/popcorn/structures.py
@@ -1,4 +1,4 @@
-from popcorn.events import Event, OneDnnEvent, LevelZeroEvent
+from popcorn.events import Event
 from abc import ABC, abstractmethod
 import os
 

--- a/popcorn/structures.py
+++ b/popcorn/structures.py
@@ -39,6 +39,14 @@ class Case:
 
         return None
 
+
+    def getfirstitem(self) -> Event | None:
+        if(len(self.events) > 0):
+            return self.events[0] if (self.events[0] != None) else None
+        
+        return None
+
+
     @property
     def title(self) -> str:
         return (

--- a/popcorn/structures.py
+++ b/popcorn/structures.py
@@ -1,51 +1,7 @@
+from popcorn.events import Event, OneDnnEvent, LevelZeroEvent
 from abc import ABC, abstractmethod
 import os
 
-
-class Event:
-    def __init__(
-        self,
-        ph="",
-        tid=-1,
-        pid=-1,
-        name="N/A",
-        cat="N/A",
-        ts=0,
-        id=-1,
-        dur=0,
-        args_id=-1,
-    ):
-        self.ph = ph
-        self.tid = tid
-        self.pid = pid
-        self.name = name
-        self.cat = cat
-        self.ts = ts
-        self.id = id
-        self.dur = dur
-        self.args_id = args_id
-
-    def __eq__(self, other):
-        if isinstance(other, Event):
-            return self.name == other.name
-        return False
-
-    def row(self) -> list[str]:
-        return [
-            self.ph,
-            str(self.tid),
-            str(self.pid),
-            self.name,
-            self.cat,
-            str(self.ts),
-            str(self.id),
-            str(self.dur),
-            str(self.args_id),
-        ]
-    
-    @staticmethod
-    def header() -> list[str]:
-        return ["ph", "tid", "pid", "name", "cat", "ts", "id", "dur", "args_id"]
 
 
 class Reader(ABC):


### PR DESCRIPTION
Purpose of this PR is to provide support for [oneDNN verbose log](https://oneapi-src.github.io/oneDNN/dev_guide_verbose.html) parsing in addition to current level one trace support. The implementation is inspired by [oneDNN/tutorials/profiling/profile_utils.py](https://github.com/oneapi-src/oneAPI-samples/blob/master/Libraries/oneDNN/tutorials/profiling/profile_utils.py) and [yehudaorel/verbose_reproducer](https://github.com/yehudaorel/verbose_reproducer). 
### TODO:
- [x] Add oneDNN log hotspots support
- [x] Add oneDNN logs kdiff support
- [ ] Add support for fusion / post-ops parsing via args[]
- [ ] Update docs (readme) w/ oneDNN log support
- [ ] Add --summary option to output overall execution time (k_diff will output difference in overall time between log1 and 2)
- [ ] Validation


### Example usage & output:
` > popcorn onednn_test_avx512_log.csv onednn_test_avx2_log.csv -cat primitive -dnnl`
``` sh

+----------------------------------------------------------------------------------------------------------------+
|                                             pops__onednn_test_log                                              |
+---------------+--------------------+---------------------+-------------------------------------+--------+------+
|      name     |        dur         |        kernel       |                shape                | ncalls | args |
+---------------+--------------------+---------------------+-------------------------------------+--------+------+
| inner_product | 178.81079869999996 |     x64:gemm:jit    |         mb1ic256ih6iw6oc4096        |  300   |  []  |
|  convolution  | 59.741455400000056 | brgconv:avx512_core | mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_ |  500   |  []  |
|    reorder    | 41.847448900000174 |       jit:uni       |              96x3x11x11             |  307   |  []  |
|    eltwise    | 11.773683300000009 |   jit:avx512_core   |              1x96x55x55             |  500   |  []  |
|    pooling    | 9.111084799999979  |   jit:avx512_core   | mb1ic96_ih55oh27kh3sh2dh0ph0_iw55ow |  300   |  []  |
|      lrn      | 5.728272599999999  | lrn_jit:avx512_core |      mb1ic96ih55iw55ls5beta0.75     |  200   |  []  |
+---------------+--------------------+---------------------+-------------------------------------+--------+------+


Displaying the most interesting 50 items out of 6:
+---------------------------------------------------------------------------------------------------------+
|                                        pops__onednn_test_avx2_log                                       |
+---------------+--------------------+--------------+-------------------------------------+--------+------+
|      name     |        dur         |    kernel    |                shape                | ncalls | args |
+---------------+--------------------+--------------+-------------------------------------+--------+------+
| inner_product | 198.3876835000001  | x64:gemm:jit |         mb1ic256ih6iw6oc4096        |  300   |  []  |
|  convolution  | 106.02465349999996 | brgconv:avx2 | mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_ |  500   |  []  |
|    reorder    | 28.85595650000006  |   jit:uni    |              96x3x11x11             |  307   |  []  |
|    eltwise    | 9.355226699999996  |   jit:avx2   |              1x96x55x55             |  500   |  []  |
|    pooling    | 8.934081000000011  |   jit:avx2   | mb1ic96_ih55oh27kh3sh2dh0ph0_iw55ow |  300   |  []  |
|      lrn      | 6.594239299999998  |   jit:avx2   |      mb1ic96ih55iw55ls5beta0.75     |  200   |  []  |
+---------------+--------------------+--------------+-------------------------------------+--------+------+


Displaying the most interesting 50 items out of 6:
+-----------------------------------------------------------------------------------------------------------------+
|                                   kdiff__onednn_test_log_onednn_test_avx2_log                                   |
+---------------------+---------------+---------------------+-------------------------------------+--------+------+
|         diff        |      name     |        kernel       |                shape                | ncalls | args |
+---------------------+---------------+---------------------+-------------------------------------+--------+------+
|  12.991492400000112 |    reorder    |       jit:uni       |              96x3x11x11             |  307   |  []  |
|  2.418456600000013  |    eltwise    |   jit:avx512_core   |              1x96x55x55             |  500   |  []  |
| 0.17700379999996763 |    pooling    |   jit:avx512_core   | mb1ic96_ih55oh27kh3sh2dh0ph0_iw55ow |  300   |  []  |
| -0.8659666999999995 |      lrn      | lrn_jit:avx512_core |      mb1ic96ih55iw55ls5beta0.75     |  200   |  []  |
|  -19.57688480000013 | inner_product |     x64:gemm:jit    |         mb1ic256ih6iw6oc4096        |  300   |  []  |
|  -46.2831980999999  |  convolution  | brgconv:avx512_core | mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_ |  500   |  []  |
+---------------------+---------------+---------------------+-------------------------------------+--------+------+

```

` > popcorn onednn_test_avx512_log.csv onednn_test_avx2_log.csv -cat primitive -dnnl`
``` sh

!!! - WARNING - !!!
If using large input files in conjunction with --no-uniques,
popcorn may degrade in performance and even crash!
Displaying the most interesting 50 items out of 2107:
+-------------------------------------------------------------------------------------------------------+
|                                         pops__onednn_test_log                                         |
+---------------+-----------+---------------------+-------------------------------------+--------+------+
|      name     |    dur    |        kernel       |                shape                | ncalls | args |
+---------------+-----------+---------------------+-------------------------------------+--------+------+
|    reorder    |  12.6531  |       jit:uni       |              96x3x11x11             |   1    |  []  |
|    reorder    |  9.77295  |       jit:uni       |              4096x4096              |   1    |  []  |
|    reorder    |  7.37891  |       jit:uni       |             384x256x3x3             |   1    |  []  |
| inner_product |  6.60596  |     x64:gemm:jit    |         mb1ic256ih6iw6oc4096        |   1    |  []  |
|  convolution  |  2.80396  | brgconv:avx512_core | g2mb1_ic96oc256_ih27oh27kh5sh1dh0ph |   1    |  []  |
.
.
.
|    reorder    | 0.0109863 |       jit:uni       |              1x256x6x6              |   1    |  []  |
|    eltwise    | 0.0109863 |   jit:avx512_core   |             1x256x13x13             |   1    |  []  |
|    reorder    | 0.0109863 |       jit:uni       |              1x256x6x6              |   1    |  []  |
|    reorder    | 0.0100098 |      simple:any     |                1x1000               |   1    |  []  |
+---------------+-----------+---------------------+-------------------------------------+--------+------+


Displaying the most interesting 50 items out of 2107:
+------------------------------------------------------------------------------------------------+
|                                   pops__onednn_test_avx2_log                                   |
+---------------+-----------+--------------+-------------------------------------+--------+------+
|      name     |    dur    |    kernel    |                shape                | ncalls | args |
+---------------+-----------+--------------+-------------------------------------+--------+------+
|    reorder    |  11.1709  |   jit:uni    |              96x3x11x11             |   1    |  []  |
|    reorder    |  7.56201  |   jit:uni    |              4096x4096              |   1    |  []  |
| inner_product |  6.31812  | brgemm:avx2  |           mb1ic4096oc4096           |   1    |  []  |
| inner_product |  5.90796  | brgemm:avx2  |           mb1ic4096oc4096           |   1    |  []  |
.
.
.
|    eltwise    | 0.0119629 |   jit:avx2   |             1x384x13x13             |   1    |  []  |
|    eltwise    | 0.0119629 |   jit:avx2   |             1x256x13x13             |   1    |  []  |
|    reorder    | 0.0119629 |   jit:uni    |              1x256x6x6              |   1    |  []  |
+---------------+-----------+--------------+-------------------------------------+--------+------+


Displaying the most interesting 50 items out of 2107:
+-------------------------------------------------------------------------------------------------------------------+
|                                    kdiff__onednn_test_log_onednn_test_avx2_log                                    |
+-----------------------+---------------+---------------------+-------------------------------------+--------+------+
|          diff         |      name     |        kernel       |                shape                | ncalls | args |
+-----------------------+---------------+---------------------+-------------------------------------+--------+------+
|        6.510014       |    reorder    |       jit:uni       |             384x256x3x3             |   1    |  []  |
|        2.21094        |    reorder    |       jit:uni       |              4096x4096              |   1    |  []  |
|        1.96704        | inner_product |     x64:gemm:jit    |         mb1ic256ih6iw6oc4096        |   1    |  []  |
|   1.4822000000000006  |    reorder    |       jit:uni       |              96x3x11x11             |   1    |  []  |
|   1.2871112999999998  |    reorder    |       jit:uni       |              1x256x6x6              |   1    |  []  |
|        0.405029       |    reorder    |       jit:uni       |             2x128x48x5x5            |   1    |  []  |
|  0.27929699999999996  |    reorder    |       jit:uni       |             1x3x227x227             |   1    |  []  |
.
.
.
|  -0.5559109999999999  |  convolution  | brgconv:avx512_core | mb1_ic256oc384_ih13oh13kh3sh1dh0ph1 |   1    |  []  |
|        -0.72021       |  convolution  | brgconv:avx512_core | g2mb1_ic96oc256_ih27oh27kh5sh1dh0ph |   1    |  []  |
|  -3.0549299999999997  | inner_product |  brgemm:avx512_core |           mb1ic4096oc1000           |   1    |  []  |
|       -5.021974       | inner_product |  brgemm:avx512_core |           mb1ic4096oc4096           |   1    |  []  |
+-----------------------+---------------+---------------------+-------------------------------------+--------+------+


```
