### PR TITLE
Removed PID & Timestamp from hotspot table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Any notable change to this project will be documented in this file.
 ## Unreleased
 
 - filter out processes that lack a duration
+- removed pid & ph from hotspot output
 
 ## [v0.0.3 Release (13-02-2024)](https://github.com/efleming-intel/popcorn/tree/v0.0.3)
 

--- a/popcorn/__about__.py
+++ b/popcorn/__about__.py
@@ -1,4 +1,4 @@
 __author__ = "Ethan Fleming"
-__credits__ = ["Ethan Fleming", "Anoop Madhusoodhanan Prabha"]
+__credits__ = ["Ethan Fleming", "Anoop Madhusoodhanan Prabha", "Orel Yehuda"]
 __email__ = "ethan.fleming@intel.com"
 __status__ = "Prototype"

--- a/popcorn/reporters.py
+++ b/popcorn/reporters.py
@@ -65,8 +65,8 @@ def report_hotspots(
     cases: list[Case], wb: Kettle | MDTables | Workbook | CSVArchive
 ):
     result = hotspots(cases)
-    hotspot_header = Event.header()
-    _report(result, hotspot_header, lambda e: e.row(), _hotspots_sheet_name, wb, [len(case.events) for case in cases])
+    hotspot_header = Event.hotspot_header()
+    _report(result, hotspot_header, lambda e: e.hotspot_row(), _hotspots_sheet_name, wb, [len(case.events) for case in cases])
 
 
 def _kernel_differences_sheet_name(item_name: str) -> str:

--- a/popcorn/structures.py
+++ b/popcorn/structures.py
@@ -26,15 +26,13 @@ class Event:
             return self.name == other.name
         return False
 
-    def row(self) -> list[str]:
+    def hotspot_row(self) -> list[str]:
         return [
             str(self.dur),
             str(self.num_calls),
             self.ph,
-            str(self.pid),
             self.name,
-            self.cat,
-            str(self.ts)
+            self.cat
         ]
     
     def kdiff_row(self) -> list[str]:
@@ -44,15 +42,13 @@ class Event:
         ]
     
     @staticmethod
-    def header() -> list[str]:
+    def hotspot_header() -> list[str]:
         return [
             "dur",
             "calls",
             "ph",
-            "pid",
             "name",
             "category",
-            "timestamp"
         ]
     
     @staticmethod
@@ -60,7 +56,7 @@ class Event:
         return [
             "diff",
             "name",
-            "cat"
+            "category"
         ]
 
 

--- a/popcorn/structures.py
+++ b/popcorn/structures.py
@@ -30,9 +30,9 @@ class Event:
         return [
             str(self.dur),
             str(self.num_calls),
-            self.ph,
             self.name,
-            self.cat
+            self.cat,
+            str(self.ts)
         ]
     
     def kdiff_row(self) -> list[str]:
@@ -46,9 +46,9 @@ class Event:
         return [
             "dur",
             "calls",
-            "ph",
             "name",
             "category",
+            "timestamp"
         ]
     
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "popcorn"
 version = "0.0.3"
-authors = [{ name = "Ethan Fleming", email = "ethan.fleming@intel.com" }]
+authors = [
+    { name = "Ethan Fleming", email = "ethan.fleming@intel.com" },
+    { name = "Orel Yehuda", email = "orel.yehuda@intel.com" }
+    ]
 description = "cross-platform kernel trace analyzer"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/tests/unit/test_reporters.py
+++ b/tests/unit/test_reporters.py
@@ -27,9 +27,9 @@ def test_hotspots_report(tmp_path: PosixPath, trace_name: str, event_names: list
     assert os.path.exists(report_path)
     with open(report_path, "r") as output_file:
         output = output_file.readlines()
-        assert output[0] == (",".join(Event.header()) + '\n')
+        assert output[0] == (",".join(Event.hotspot_header()) + '\n')
         for event in events:
-            assert (",".join(event.row()) + '\n') in output
+            assert (",".join(event.hotspot_row()) + '\n') in output
 
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])

--- a/tests/unit/test_structures.py
+++ b/tests/unit/test_structures.py
@@ -36,8 +36,6 @@ def test_event_row():
     result_row = event.hotspot_row()
 
     expected_vals = list(event_dict.values())
-    print(expected_vals)
-    print(result_row)
 
     for s in result_row:
         s = int(s) if s.isdigit() else str(s)

--- a/tests/unit/test_structures.py
+++ b/tests/unit/test_structures.py
@@ -7,9 +7,9 @@ def test_initialized_event_defaults():
     event = Event()
     assert event.dur == 0
     assert event.num_calls == 1
-    assert event.ph == ""
     assert event.name == "N/A"
     assert event.cat == "N/A"
+    assert event.ts == 0
 
 
 def test_event_equivalence():
@@ -25,9 +25,9 @@ def test_event_row():
     event_dict: dict[str, str | int] = {
         "dur": 3459876,
         "calls": 1,
-        "ph": "X",
         "name": "gen_conv",
         "cat": "gpu_op",
+        "ts": 87612348765
     }
     event = Event()
     for prop in event_dict.keys():
@@ -48,9 +48,9 @@ def test_event_header():
     expected_hotspot_header = [
             "dur",
             "calls",
-            "ph",
             "name",
-            "category"
+            "category",
+            "timestamp"
         ]
     expected_kdiff_header = [
             "diff",

--- a/tests/unit/test_structures.py
+++ b/tests/unit/test_structures.py
@@ -27,16 +27,14 @@ def test_event_row():
     event_dict: dict[str, str | int] = {
         "dur": 3459876,
         "ph": "X",
-        "pid": 1,
         "name": "gen_conv",
         "cat": "gpu_op",
-        "ts": 87612348765
     }
     event = Event()
     for prop in event_dict.keys():
         setattr(event, prop, event_dict[prop])
     
-    result_row = event.row()
+    result_row = event.hotspot_row()
 
     expected_vals = list(event_dict.values())
 
@@ -48,27 +46,25 @@ def test_event_row():
 
 
 def test_event_header():
-    expected_header = [
+    expected_hotspot_header = [
             "dur",
             "calls",
             "ph",
-            "pid",
             "name",
-            "category",
-            "timestamp"
+            "category"
         ]
     expected_kdiff_header = [
             "diff",
             "name",
             "cat"
         ]
-    actual_header = Event.header()
+    actual_hotspot_header = Event.hotspot_header()
     actual_kdiff_header = Event.kdiff_header()
 
-    for s in expected_header:
-        assert s in actual_header
-    for s in actual_header:
-        assert s in expected_header
+    for s in expected_hotspot_header:
+        assert s in actual_hotspot_header
+    for s in actual_hotspot_header:
+        assert s in expected_hotspot_header
 
     for s in expected_kdiff_header:
         assert s in actual_kdiff_header

--- a/tests/unit/test_structures.py
+++ b/tests/unit/test_structures.py
@@ -8,10 +8,8 @@ def test_initialized_event_defaults():
     assert event.dur == 0
     assert event.num_calls == 1
     assert event.ph == ""
-    assert event.pid == -1
     assert event.name == "N/A"
     assert event.cat == "N/A"
-    assert event.ts == 0
 
 
 def test_event_equivalence():
@@ -19,13 +17,14 @@ def test_event_equivalence():
     other = Event(name="test", dur=654)
     another = Event(name="other")
 
-    assert event == other and event != event.row()
+    assert event == other and event != event.hotspot_row()
     assert event != another
 
 
 def test_event_row():
     event_dict: dict[str, str | int] = {
         "dur": 3459876,
+        "calls": 1,
         "ph": "X",
         "name": "gen_conv",
         "cat": "gpu_op",
@@ -37,6 +36,8 @@ def test_event_row():
     result_row = event.hotspot_row()
 
     expected_vals = list(event_dict.values())
+    print(expected_vals)
+    print(result_row)
 
     for s in result_row:
         s = int(s) if s.isdigit() else str(s)

--- a/tests/unit/test_structures.py
+++ b/tests/unit/test_structures.py
@@ -56,7 +56,7 @@ def test_event_header():
     expected_kdiff_header = [
             "diff",
             "name",
-            "cat"
+            "category"
         ]
     actual_hotspot_header = Event.hotspot_header()
     actual_kdiff_header = Event.kdiff_header()


### PR DESCRIPTION
- Renamed header & row to hotspot_header / hotspot_row.
- Removed unneeded PID and timestamp from hotspot output.